### PR TITLE
🐛 replace all ampersands in each cafe name

### DIFF
--- a/convert-data-to-gpx.sh
+++ b/convert-data-to-gpx.sh
@@ -5,4 +5,4 @@ cafesData="${1:?must provide cafes data file as argument to script}"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-cat "$SCRIPT_DIR/header" <(jq -r '.[]| "  <wpt lat=\"\(.latitude)\" lon=\"\(.longitude)\">\n    <name>\(.title | sub("&";"&amp;"))</name>\n    <sym>Flag, Blue</sym>\n    <type>user</type>\n  </wpt>\n"' "$cafesData") <(echo "</gpx>")
+cat "$SCRIPT_DIR/header" <(jq -r '.[]| "  <wpt lat=\"\(.latitude)\" lon=\"\(.longitude)\">\n    <name>\(.title | gsub("&";"&amp;"))</name>\n    <sym>Flag, Blue</sym>\n    <type>user</type>\n  </wpt>\n"' "$cafesData") <(echo "</gpx>")

--- a/halfway-coffee.gpx
+++ b/halfway-coffee.gpx
@@ -112,7 +112,7 @@
   </wpt>
 
   <wpt lat="54.1276" lon="-0.485736">
-    <name>B &amp; F Potatoes Ltd & Bannisters Farm Shop</name>
+    <name>B &amp; F Potatoes Ltd &amp; Bannisters Farm Shop</name>
     <sym>Flag, Blue</sym>
     <type>user</type>
   </wpt>

--- a/testdata/cafes.json
+++ b/testdata/cafes.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "252",
-    "title": "Bar & Baz",
+    "title": "Bar & Baz & Shoop",
     "times": "",
     "address": "Station Road",
     "website": "http://www.1923.coffee/",

--- a/testdata/expected.gpx
+++ b/testdata/expected.gpx
@@ -10,7 +10,7 @@
   </metadata>
 
   <wpt lat="3" lon="4">
-    <name>Bar &amp; Baz</name>
+    <name>Bar &amp; Baz &amp; Shoop</name>
     <sym>Flag, Blue</sym>
     <type>user</type>
   </wpt>


### PR DESCRIPTION
The fix in https://github.com/glynternet/halfway-coffee-gpx/pull/7 only subbed the first ampersand of each name, but some cafes have multiple.